### PR TITLE
Update README.md to check first macOS command before running second

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ RHEL/Fedora et al:
 ```sudo dnf install libssl-devel```
 
 MacOS
-```brew install gettext; brew install openssl```
+```brew install gettext && brew install openssl```
 To compile on mac you need to edit the Makefile to point to openssl@3 within the homebrew install dir
 
 ## Author


### PR DESCRIPTION
This pull request updates the installation instructions in the `README.md` file to improve clarity and correctness.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L33-R33): Updated the MacOS installation command to use `&&` instead of `;` for chaining `brew install` commands, ensuring the second command only runs if the first one succeeds.