### PR TITLE
add expired certificate detection & add it.po on script translate

### DIFF
--- a/src/en.po
+++ b/src/en.po
@@ -2,12 +2,11 @@
 # Copyright (C) 2025 Alexia Michelle
 # This file is distributed under the same license as the sslcheck package.
 # Alexia Michelle <alexia@goldendoglinux.org>, 2025.
-
 msgid ""
 msgstr ""
 "Project-Id-Version: sslcheck 1.2.0\n"
-"Report-Msgid-Bugs-To: alexia@goldendoglinux.org\n"
-"POT-Creation-Date: 2025-06-15 21:03-0300\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-06-16 08:36-0600\n"
 "PO-Revision-Date: 2025-06-15 21:10-0300\n"
 "Last-Translator: Alexia Michelle <alexia@goldendoglinux.org>\n"
 "Language-Team: English <en@li.org>\n"
@@ -27,7 +26,8 @@ msgid ""
 "sslcheck <domain>         prints domain and remainder of days until cert "
 "expires\n"
 msgstr ""
-"sslcheck <domain>         prints domain and remainder of days until cert expires\n"
+"sslcheck <domain>         prints domain and remainder of days until cert "
+"expires\n"
 
 #: sslcheck.c:67
 #, c-format
@@ -54,32 +54,42 @@ msgstr "-h --help                 prints this menu\n"
 msgid "-v --version              prints version\n"
 msgstr "-v --version              prints version\n"
 
-#: sslcheck.c:138
+#: sslcheck.c:152
 #, c-format
 msgid "Error creating SSL context\n"
 msgstr "Error creating SSL context\n"
 
-#: sslcheck.c:153
+#: sslcheck.c:167
 #, c-format
 msgid "Error getting SSL object\n"
 msgstr "Error getting SSL object\n"
 
-#: sslcheck.c:166
+#: sslcheck.c:180
 #, c-format
 msgid "Error connecting to %s\n"
 msgstr "Error connecting to %s\n"
 
-#: sslcheck.c:177
+#: sslcheck.c:191
 #, c-format
 msgid "No certificate found for %s\n"
 msgstr "No certificate found for %s\n"
 
-#: sslcheck.c:188
+#: sslcheck.c:204
 #, c-format
 msgid "Could not calculate certificate expiration\n"
 msgstr "Could not calculate certificate expiration\n"
 
-#: sslcheck.c:195
+#: sslcheck.c:214
+#, c-format
+msgid "Expired %d days ago\n"
+msgstr "Expired %d days ago\n"
+
+#: sslcheck.c:220
+#, c-format
+msgid "Domain: %s | Certificate EXPIRED %d days ago\n"
+msgstr "Domain: %s | Certificate EXPIRED %d days ago\n"
+
+#: sslcheck.c:222
 #, c-format
 msgid "Domain: %s | Days until Certification expires: %d\n"
 msgstr "Domain: %s | Days until Certification expires: %d\n"

--- a/src/es.po
+++ b/src/es.po
@@ -2,12 +2,11 @@
 # Copyright (C) 2025 Alexia Michelle
 # This file is distributed under the same license as the sslcheck package.
 # Alexia Michelle <alexia@goldendoglinux.org>, 2025.
-
 msgid ""
 msgstr ""
 "Project-Id-Version: sslcheck 1.2.0\n"
-"Report-Msgid-Bugs-To: alexia@goldendoglinux.org\n"
-"POT-Creation-Date: 2025-06-15 21:03-0300\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-06-16 08:36-0600\n"
 "PO-Revision-Date: 2025-06-15 21:10-0300\n"
 "Last-Translator: Alexia Michelle <alexia@goldendoglinux.org>\n"
 "Language-Team: Spanish <es@li.org>\n"
@@ -27,7 +26,8 @@ msgid ""
 "sslcheck <domain>         prints domain and remainder of days until cert "
 "expires\n"
 msgstr ""
-"sslcheck <dominio>         muestra el dominio y los días restantes hasta que expire el certificado\n"
+"sslcheck <dominio>         muestra el dominio y los días restantes hasta que "
+"expire el certificado\n"
 
 #: sslcheck.c:67
 #, c-format
@@ -54,32 +54,42 @@ msgstr "-h --help                  muestra este menú\n"
 msgid "-v --version              prints version\n"
 msgstr "-v --version               muestra la versión\n"
 
-#: sslcheck.c:138
+#: sslcheck.c:152
 #, c-format
 msgid "Error creating SSL context\n"
 msgstr "Error creando el contexto SSL\n"
 
-#: sslcheck.c:153
+#: sslcheck.c:167
 #, c-format
 msgid "Error getting SSL object\n"
 msgstr "Error obteniendo el objeto SSL\n"
 
-#: sslcheck.c:166
+#: sslcheck.c:180
 #, c-format
 msgid "Error connecting to %s\n"
 msgstr "Error al conectar a %s\n"
 
-#: sslcheck.c:177
+#: sslcheck.c:191
 #, c-format
 msgid "No certificate found for %s\n"
 msgstr "No se encontró certificado para %s\n"
 
-#: sslcheck.c:188
+#: sslcheck.c:204
 #, c-format
 msgid "Could not calculate certificate expiration\n"
 msgstr "No se pudo calcular la expiración del certificado\n"
 
-#: sslcheck.c:195
+#: sslcheck.c:214
+#, c-format
+msgid "Expired %d days ago\n"
+msgstr "Caducado hace %d días\n"
+
+#: sslcheck.c:220
+#, c-format
+msgid "Domain: %s | Certificate EXPIRED %d days ago\n"
+msgstr "Dominio: %s | Certificado caducado hace %d días\n"
+
+#: sslcheck.c:222
 #, c-format
 msgid "Domain: %s | Days until Certification expires: %d\n"
 msgstr "Dominio: %s | Días hasta que vence el certificado: %d\n"

--- a/src/fr.po
+++ b/src/fr.po
@@ -2,12 +2,11 @@
 # Copyright (C) 2025 Alexia Michelle
 # This file is distributed under the same license as the sslcheck package.
 # Alexia Michelle <alexia@goldendoglinux.org>, 2025.
-
 msgid ""
 msgstr ""
 "Project-Id-Version: sslcheck 1.2.0\n"
-"Report-Msgid-Bugs-To: alexia@goldendoglinux.org\n"
-"POT-Creation-Date: 2025-06-15 21:03-0300\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-06-16 08:36-0600\n"
 "PO-Revision-Date: 2025-06-15 21:10-0300\n"
 "Last-Translator: Alexia Michelle <alexia@goldendoglinux.org>\n"
 "Language-Team: French <fr@li.org>\n"
@@ -27,7 +26,8 @@ msgid ""
 "sslcheck <domain>         prints domain and remainder of days until cert "
 "expires\n"
 msgstr ""
-"sslcheck <domaine>         affiche le domaine et le nombre de jours restants avant l'expiration du certificat\n"
+"sslcheck <domaine>         affiche le domaine et le nombre de jours restants "
+"avant l'expiration du certificat\n"
 
 #: sslcheck.c:67
 #, c-format
@@ -42,7 +42,8 @@ msgstr "-j --json <domaine>        affiche la sortie au format JSON\n"
 #: sslcheck.c:69
 #, c-format
 msgid "-p --port <port>          use custom port instead of 443\n"
-msgstr "-p --port <port>           utilise un port personnalisé à la place de 443\n"
+msgstr ""
+"-p --port <port>           utilise un port personnalisé à la place de 443\n"
 
 #: sslcheck.c:70
 #, c-format
@@ -54,32 +55,42 @@ msgstr "-h --help                  affiche ce menu\n"
 msgid "-v --version              prints version\n"
 msgstr "-v --version               affiche la version\n"
 
-#: sslcheck.c:138
+#: sslcheck.c:152
 #, c-format
 msgid "Error creating SSL context\n"
 msgstr "Erreur lors de la création du contexte SSL\n"
 
-#: sslcheck.c:153
+#: sslcheck.c:167
 #, c-format
 msgid "Error getting SSL object\n"
 msgstr "Erreur lors de l'obtention de l'objet SSL\n"
 
-#: sslcheck.c:166
+#: sslcheck.c:180
 #, c-format
 msgid "Error connecting to %s\n"
 msgstr "Erreur de connexion à %s\n"
 
-#: sslcheck.c:177
+#: sslcheck.c:191
 #, c-format
 msgid "No certificate found for %s\n"
 msgstr "Aucun certificat trouvé pour %s\n"
 
-#: sslcheck.c:188
+#: sslcheck.c:204
 #, c-format
 msgid "Could not calculate certificate expiration\n"
 msgstr "Impossible de calculer l'expiration du certificat\n"
 
-#: sslcheck.c:195
+#: sslcheck.c:214
+#, c-format
+msgid "Expired %d days ago\n"
+msgstr "Expiré il y a %d jours\n"
+
+#: sslcheck.c:220
+#, c-format
+msgid "Domain: %s | Certificate EXPIRED %d days ago\n"
+msgstr "Domaine : %s | Certificat expiré il y a %d jours\n"
+
+#: sslcheck.c:222
 #, c-format
 msgid "Domain: %s | Days until Certification expires: %d\n"
 msgstr "Domaine: %s | Jours restants avant expiration du certificat: %d\n"

--- a/src/it.po
+++ b/src/it.po
@@ -2,12 +2,11 @@
 # Copyright (C) 2025 Alexia Michelle
 # This file is distributed under the same license as the sslcheck package.
 # Alexia Michelle <alexia@goldendoglinux.org>, 2025.
-
 msgid ""
 msgstr ""
 "Project-Id-Version: sslcheck 1.2.0\n"
-"Report-Msgid-Bugs-To: alexia@goldendoglinux.org\n"
-"POT-Creation-Date: 2025-06-15 21:03-0300\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-06-16 08:36-0600\n"
 "PO-Revision-Date: 2025-06-15 21:10-0300\n"
 "Last-Translator: Alexia Michelle <alexia@goldendoglinux.org>\n"
 "Language-Team: Italian <it@li.org>\n"
@@ -27,7 +26,8 @@ msgid ""
 "sslcheck <domain>         prints domain and remainder of days until cert "
 "expires\n"
 msgstr ""
-"sslcheck <dominio>         mostra il dominio e i giorni rimanenti fino alla scadenza del certificato\n"
+"sslcheck <dominio>         mostra il dominio e i giorni rimanenti fino alla "
+"scadenza del certificato\n"
 
 #: sslcheck.c:67
 #, c-format
@@ -42,7 +42,8 @@ msgstr "-j --json <dominio>        mostra l'output in formato JSON\n"
 #: sslcheck.c:69
 #, c-format
 msgid "-p --port <port>          use custom port instead of 443\n"
-msgstr "-p --port <porta>          usa una porta personalizzata invece di 443\n"
+msgstr ""
+"-p --port <porta>          usa una porta personalizzata invece di 443\n"
 
 #: sslcheck.c:70
 #, c-format
@@ -54,32 +55,42 @@ msgstr "-h --help                  mostra questo menu\n"
 msgid "-v --version              prints version\n"
 msgstr "-v --version               mostra la versione\n"
 
-#: sslcheck.c:138
+#: sslcheck.c:152
 #, c-format
 msgid "Error creating SSL context\n"
 msgstr "Errore nella creazione del contesto SSL\n"
 
-#: sslcheck.c:153
+#: sslcheck.c:167
 #, c-format
 msgid "Error getting SSL object\n"
 msgstr "Errore nell'ottenimento dell'oggetto SSL\n"
 
-#: sslcheck.c:166
+#: sslcheck.c:180
 #, c-format
 msgid "Error connecting to %s\n"
 msgstr "Errore di connessione a %s\n"
 
-#: sslcheck.c:177
+#: sslcheck.c:191
 #, c-format
 msgid "No certificate found for %s\n"
 msgstr "Nessun certificato trovato per %s\n"
 
-#: sslcheck.c:188
+#: sslcheck.c:204
 #, c-format
 msgid "Could not calculate certificate expiration\n"
 msgstr "Impossibile calcolare la scadenza del certificato\n"
 
-#: sslcheck.c:195
+#: sslcheck.c:214
+#, c-format
+msgid "Expired %d days ago\n"
+msgstr "Scaduto %d giorni fa\n"
+
+#: sslcheck.c:220
+#, c-format
+msgid "Domain: %s | Certificate EXPIRED %d days ago\n"
+msgstr "Dominio: %s | Certificato SCADUTO %d giorni fa\n"
+
+#: sslcheck.c:222
 #, c-format
 msgid "Domain: %s | Days until Certification expires: %d\n"
 msgstr "Dominio: %s | Giorni fino alla scadenza del certificato: %d\n"

--- a/src/rebuild-translatable-strings.sh
+++ b/src/rebuild-translatable-strings.sh
@@ -8,4 +8,5 @@ xgettext -k_ -o sslcheck.pot sslcheck.c
 msgmerge --update es.po sslcheck.pot
 msgmerge --update fr.po sslcheck.pot
 msgmerge --update en.po sslcheck.pot
+msgmerge --update it.po sslcheck.pot
 echo "strings updated. Review the lines that require translation"

--- a/src/sslcheck.pot
+++ b/src/sslcheck.pot
@@ -1,20 +1,20 @@
-# Translations template for sslcheck.
-# Copyright (C) 2025 Alexia Michelle
-# This file is distributed under the same license as the sslcheck package.
-# Alexia Michelle <alexia@goldendoglinux.org>, 2025.
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-
+#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: sslcheck 1.2.0\n"
-"Report-Msgid-Bugs-To: alexia@goldendoglinux.org\n"
-"POT-Creation-Date: 2025-06-15 21:03-0300\n"
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-06-16 08:36-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
 #: sslcheck.c:58 sslcheck.c:64
@@ -54,32 +54,42 @@ msgstr ""
 msgid "-v --version              prints version\n"
 msgstr ""
 
-#: sslcheck.c:138
+#: sslcheck.c:152
 #, c-format
 msgid "Error creating SSL context\n"
 msgstr ""
 
-#: sslcheck.c:153
+#: sslcheck.c:167
 #, c-format
 msgid "Error getting SSL object\n"
 msgstr ""
 
-#: sslcheck.c:166
+#: sslcheck.c:180
 #, c-format
 msgid "Error connecting to %s\n"
 msgstr ""
 
-#: sslcheck.c:177
+#: sslcheck.c:191
 #, c-format
 msgid "No certificate found for %s\n"
 msgstr ""
 
-#: sslcheck.c:188
+#: sslcheck.c:204
 #, c-format
 msgid "Could not calculate certificate expiration\n"
 msgstr ""
 
-#: sslcheck.c:195
+#: sslcheck.c:214
+#, c-format
+msgid "Expired %d days ago\n"
+msgstr ""
+
+#: sslcheck.c:220
+#, c-format
+msgid "Domain: %s | Certificate EXPIRED %d days ago\n"
+msgstr ""
+
+#: sslcheck.c:222
 #, c-format
 msgid "Domain: %s | Days until Certification expires: %d\n"
 msgstr ""


### PR DESCRIPTION
Buenas días, agregue que si el certificado ya ha expirado regrese los días que han pasado desde que caduco

Ejemplo:

Dominio: ejemplo-cadudo.com | Certificado caducado hace 17 días

Me mencionaste que habías implementado el flag --short, esta de la siguiente forma:

```
./sslcheck --short ejemplo-cadudo.com
Expired 17 days ago   
```

Gracias por agregar el script para las traducciones, a por cierto lo actualize para agregar el idioma italiano